### PR TITLE
💚 fix: update builder step in Dockerfile

### DIFF
--- a/go/gin/Dockerfile
+++ b/go/gin/Dockerfile
@@ -1,7 +1,10 @@
 FROM golang:1.22 as build
 WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
 COPY . .
-RUN go build -o /server .
+ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+RUN go build -ldflags="-s -w" -o /server .
 
 FROM scratch
 COPY --from=build /server /server


### PR DESCRIPTION
Closes #32

Refs: https://dev.to/koddr/build-a-restful-api-on-go-fiber-postgresql-jwt-and-swagger-docs-in-isolated-docker-containers-475j#dockerfile-for-the-fiber-app