### PR TITLE
Fix turborepo cd start issue

### DIFF
--- a/turbo-nextjs/README.md
+++ b/turbo-nextjs/README.md
@@ -11,6 +11,6 @@
 Configuration to use the `--filter` option with Turbo for launching specific applications. Ensures that only the targeted application is started, enhancing resource efficiency and simplifying the startup process (every app can be created as a separate Coolify Application).
 - Set `Build Pack` to `nixpacks`.
 - Set the build command to `npm run build --filter=web`,
-- Set the start command to `npm run start --filter=web`.
+- Set the start command to `cd apps/web && npm run start`.
    - `npm` could be different depending on the package manager you are using (`Nixpacks` decides based on the lock file).
 - That's all.


### PR DESCRIPTION
Updated readme of the turborepo example to state that the directory needs to be changed for the start command since the turbo.json does not have any start task/pipeline