### PR TITLE
Add reproducer for coolify#8953

### DIFF
--- a/docker-compose-preserve-repo-env/README.md
+++ b/docker-compose-preserve-repo-env/README.md
@@ -1,0 +1,38 @@
+# Reproducer for coolify#8953
+
+Minimal Docker Compose app that uses `${WEB_PORT}` variable interpolation to
+reproduce the `.env not found` error when **Preserve Repository** is enabled
+with a custom start command.
+
+## Steps to reproduce
+
+1. In Coolify, create a **Docker Compose** application pointing to this
+   repository subdirectory (`docker-compose-preserve-repo-env`).
+2. Add an environment variable: `WEB_PORT=9090`.
+3. In **Advanced** settings, enable **Preserve Repository**.
+4. Set the custom start command to:
+   ```
+   docker compose -f docker-compose.yaml -f docker-compose.prod.yaml up -d
+   ```
+5. Deploy.
+
+### Expected (after fix)
+
+Deployment succeeds. `--project-directory` in the `up -d` command points to
+`/data/coolify/applications/{uuid}` (host path where `.env` exists).
+
+### Actual (before fix)
+
+Deployment fails with:
+
+```
+env file /artifacts/{deployment_uuid}/.env not found
+```
+
+Because `--project-directory` was set to `/artifacts/{deployment_uuid}` (helper
+container path), and Docker Compose resolves `env_file` directives relative to
+that directory.
+
+## Related
+
+- https://github.com/coollabsio/coolify/issues/8953

--- a/docker-compose-preserve-repo-env/docker-compose.prod.yaml
+++ b/docker-compose-preserve-repo-env/docker-compose.prod.yaml
@@ -1,0 +1,3 @@
+services:
+  web:
+    restart: always

--- a/docker-compose-preserve-repo-env/docker-compose.yaml
+++ b/docker-compose-preserve-repo-env/docker-compose.yaml
@@ -1,0 +1,5 @@
+services:
+  web:
+    image: nginx:alpine
+    ports:
+      - "${WEB_PORT:-8080}:80"


### PR DESCRIPTION
## Summary
- Adds `docker-compose-preserve-repo-env` example directory
- Minimal nginx + `${WEB_PORT}` interpolation to reproduce the `.env not found` error when **Preserve Repository** is enabled with a custom start command
- Includes `docker-compose.prod.yaml` overlay and README with step-by-step repro instructions

## Related
- https://github.com/coollabsio/coolify/issues/8953

🤖 Generated with [Claude Code](https://claude.com/claude-code)