### PR TITLE
Add example to reproduce issue #8854: env var fallback in volume paths

### DIFF
--- a/docker-compose-env-var-fallback-volume/README.md
+++ b/docker-compose-env-var-fallback-volume/README.md
@@ -1,0 +1,11 @@
+# Docker Compose - Environment Variable Fallback Volume
+
+Reproduces [issue #8854](https://github.com/coollabsio/coolify/issues/8854): the "Convert to file" button in Persistent Storage UI fails for volume paths using variables with fallback values (`${VAR:-./path}`).
+
+## How to reproduce
+
+1. Deploy this as a **Docker Compose** application from this Git repository.
+2. Go to the **Persistent Storage** tab.
+3. The `${CONFIG_FILE:-./default-config.yaml}` mount is listed as a directory.
+4. Click **"Convert to file"** on that mount.
+5. Expected: converts to file. Actual: throws `Invalid storage path: contains forbidden character '${' (variable substitution with potential command injection)`.

--- a/docker-compose-env-var-fallback-volume/default-config.yaml
+++ b/docker-compose-env-var-fallback-volume/default-config.yaml
@@ -1,0 +1,9 @@
+server {
+    listen 80;
+    server_name localhost;
+
+    location / {
+        root /usr/share/nginx/html;
+        index index.html;
+    }
+}

--- a/docker-compose-env-var-fallback-volume/docker-compose.yaml
+++ b/docker-compose-env-var-fallback-volume/docker-compose.yaml
@@ -1,0 +1,8 @@
+services:
+  web:
+    image: nginx:alpine
+    volumes:
+      - type: bind
+        source: '${CONFIG_FILE:-./default-config.yaml}'
+        target: /etc/nginx/conf.d/custom.conf
+        read_only: true


### PR DESCRIPTION
Demonstrates that array/long syntax volumes with ${VAR:-default} fallback values cause "Convert to file" to fail with a command injection error.