### PR TITLE
Add docker-compose bind mount preview test case

### DIFF
--- a/docker-compose-bind-mount-preview/README.md
+++ b/docker-compose-bind-mount-preview/README.md
@@ -1,0 +1,19 @@
+# Docker Compose Bind Mount Preview Test
+
+Test case for [coolify#7802](https://github.com/coollabsio/coolify/issues/7802) — volume mappings from repo content in Preview Deployments.
+
+## Setup
+
+1. Add this repo as a Docker Compose resource in Coolify
+2. Set the base directory to `/docker-compose-bind-mount-preview`
+3. Deploy — should succeed (db_bootstrap runs the script from `./scripts`)
+4. Enable **Preview Deployments**
+5. Open a PR and deploy the preview
+
+## Expected
+
+The preview deployment should work the same as the main deployment — the `./scripts` bind mount should resolve to the repo's `scripts/` directory.
+
+## Actual (bug)
+
+The preview deployment fails because Coolify appends `-pr-N` to the bind mount path, looking for `scripts-pr-1` which doesn't exist.

--- a/docker-compose-bind-mount-preview/docker-compose.yml
+++ b/docker-compose-bind-mount-preview/docker-compose.yml
@@ -1,0 +1,42 @@
+services:
+
+  postgres:
+    image: postgres:16.4
+    container_name: postgres_test
+    restart: always
+    environment:
+      POSTGRES_USER: ${COMPOSE__POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${COMPOSE__POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${COMPOSE__POSTGRES_DB:-postgres}
+    expose:
+      - "5432"
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
+      interval: 10s
+      retries: 5
+      start_period: 10s
+
+  db_bootstrap:
+    image: postgres:16.4
+    container_name: db_bootstrap_test
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DB_HOST: ${COMPOSE__POSTGRES_HOST:-postgres}
+      DB_NAME: ${COMPOSE__POSTGRES_DB:-postgres}
+      DB_USER: ${COMPOSE__POSTGRES_USER:-postgres}
+      PGPASSWORD: ${COMPOSE__POSTGRES_PASSWORD:-postgres}
+    volumes:
+      - ./scripts:/scripts:ro
+    entrypoint: [ "bash", "/scripts/bootstrap_db.sh" ]
+    restart: "no"
+
+  main_service:
+    image: nginx:latest
+    container_name: nginx_server
+    ports:
+      - '0:80'
+    depends_on:
+      db_bootstrap:
+        condition: service_completed_successfully

--- a/docker-compose-bind-mount-preview/scripts/bootstrap_db.sh
+++ b/docker-compose-bind-mount-preview/scripts/bootstrap_db.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+echo "Waiting for PostgreSQL to be ready..."
+until psql -h "$DB_HOST" -U "$DB_USER" -d "$DB_NAME" -c '\q' 2>/dev/null; do
+  sleep 1
+done
+
+echo "Creating test table..."
+psql -h "$DB_HOST" -U "$DB_USER" -d "$DB_NAME" <<SQL
+CREATE TABLE IF NOT EXISTS test_table (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+INSERT INTO test_table (name) VALUES ('hello from bootstrap');
+SQL
+
+echo "Bootstrap complete!"


### PR DESCRIPTION
## Summary
- Adds a test case for [coolify#7802](https://github.com/coollabsio/coolify/issues/7802)
- Reproduces the bug where bind mount volumes from repo content get an incorrect `-pr-N` suffix during Preview Deployments
- Includes a postgres + bootstrap script + nginx setup with `./scripts:/scripts:ro` bind mount

## How to use
1. Add this repo as a Docker Compose resource, base directory `/docker-compose-bind-mount-preview`
2. Deploy normally (works)
3. Enable Preview Deployments, open a PR, deploy preview (fails with `scripts-pr-1` not found)

🤖 Generated with [Claude Code](https://claude.com/claude-code)